### PR TITLE
fix: output encoding 'handle is invalid' error in build script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ skip_tags: true
 clone_depth: 1
 
 install:
-  - ps: iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current
+  - ps: (& cmd /c); iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk -channel current
   - ps: 'Get-CimInstance win32_operatingsystem -Property Caption, OSArchitecture, Version | fl Caption, OSArchitecture, Version'
   - ps: $PSVersionTable
   - c:\opscode\chefdk\bin\chef.bat exec ruby --version


### PR DESCRIPTION
- Fix output encoding error in PowerShell script.  It's polluting the otherwise clean looking build log.  The solution is to start a cmd console so that [Console]::OutputEncoding has something to modify.  Whether or not you encounter the error depends on how you invoke PowerShell.  Some contexts include a cmd console already, while others do not.