### PR TITLE
Upgrade to latest BeyondCompare 4.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of beyondcompare.
 
+## 2.0.2
+
+* Upgrade BeyondCompare to 4.2.9
+
 ## 2.0.1
 
 * Upgrade BeyondCompare to 4.2.7

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,11 +18,11 @@
 # limitations under the License.
 #
 
-default['beyondcompare']['version'] = '4.2.7.23425'
+default['beyondcompare']['version'] = '4.2.9.23626'
 default['beyondcompare']['source'] = 'http://www.scootersoftware.com/'
 
-default['beyondcompare']['package_name'] = 'Beyond Compare 4.2.7'
-default['beyondcompare']['checksum'] = 'a3b45191a25505de429d25bd354a8fbd259693c6b0b0b778c898c0e1c1f685af'
+default['beyondcompare']['package_name'] = 'Beyond Compare 4.2.9'
+default['beyondcompare']['checksum'] = '366e78cb7ffd536fbc4a42dbecb094a41a008f30439c95e760710f0ec7b1f300'
 
 default['beyondcompare']['bcompare_exe'] =
   ::File.join((ENV['ProgramFiles'] || 'C:\Program Files'), 'Beyond Compare 4', 'BCompare.exe')

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,6 @@ chef_version     '>= 13.0' if respond_to?(:chef_version)
 license          'Apache-2.0'
 description      'Installs/Configures Beyond Compare'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.1'
+version          '2.0.2'
 supports         'windows'
 depends          'windows'

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -4,10 +4,10 @@ describe 'beyondcompare::install' do
     end.converge(described_recipe)
   end
   it 'installs Beyond Compare' do
-    expect(chef_run).to install_windows_package('Beyond Compare 4.2.7')
+    expect(chef_run).to install_windows_package('Beyond Compare 4.2.9')
       .with(
-        source: 'http://www.scootersoftware.com/BCompare-4.2.7.23425.exe',
-        checksum: 'a3b45191a25505de429d25bd354a8fbd259693c6b0b0b778c898c0e1c1f685af',
+        source: 'http://www.scootersoftware.com/BCompare-4.2.9.23626.exe',
+        checksum: '366e78cb7ffd536fbc4a42dbecb094a41a008f30439c95e760710f0ec7b1f300',
         installer_type: :inno
       )
   end


### PR DESCRIPTION
This PR updates the version of Beyond Compare to 4.2.9.